### PR TITLE
ci: always run CI in main or master

### DIFF
--- a/.github/workflows/kitchen.yml
+++ b/.github/workflows/kitchen.yml
@@ -21,7 +21,10 @@ jobs:
 
   list:
     needs: pre_build
-    if: ${{ needs.pre_build.outputs.should_skip != 'true' }}
+    # always run CI in main (or master) branch so that cache in main can be
+    # reused in pull_request or push. this reduces the number of box download.
+    # vagrant cloud throttles requests after many download requests.
+    if: ${{ needs.pre_build.outputs.should_skip != 'true' || github.ref_name == 'main' || github.ref_name == 'master' }}
     runs-on: macos-10.15
     outputs:
       instances: ${{ steps.set-instances.outputs.instances }}
@@ -45,7 +48,7 @@ jobs:
     needs:
       - pre_build
       - list
-    if: ${{ needs.pre_build.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre_build.outputs.should_skip != 'true' || github.ref_name == 'main' || github.ref_name == 'master' }}
     strategy:
       matrix:
         instance: ${{ fromJSON(needs.list.outputs.instances) }}


### PR DESCRIPTION
so that caches in master can be used in future branches